### PR TITLE
Re-Enable the ability to Linked Clone from a template

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
+++ b/lib/chef/provisioning/vsphere_driver/clone_spec_builder.rb
@@ -70,11 +70,11 @@ module ChefProvisioningVsphere
 
       if options[:use_linked_clone]
         if vm_template.config.template
-          Chef::Log.warn("Using a VM Template, ignoring use_linked_clone.")
-        else
-          vsphere_helper.create_delta_disk(vm_template)
-          rspec.diskMoveType = :moveChildMostDiskBacking
+          Chef::Log.warn("Using a VM Template and use_linked_clone is might cause issues in certain environments.")
         end
+        vsphere_helper.create_delta_disk(vm_template)
+        rspec.diskMoveType = :moveChildMostDiskBacking
+      
       end
 
       unless options[:datastore].to_s.empty?


### PR DESCRIPTION
I am not convinced that linked cloning from a template is actually unsupported.  It works perfectly fine on our vSphere 6.0 clusters and I feel that the protection that Templates provide is even more necessary for Linked Clones as changes to the root snapshots would cause major problems for all linked clones.

Keeping this PR open while I burn in the Linked Clones from templates a bit before PRing back to upstream
